### PR TITLE
Adding an "await" at the end of the writeBundle

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -200,7 +200,7 @@ function mapOptimizer(
                 }
             }
 
-            fs.promises.mkdir(path.dirname(optimizedMapFilePath), { recursive: true }).then(() => {
+            await fs.promises.mkdir(path.dirname(optimizedMapFilePath), { recursive: true }).then(() => {
                 fs.promises.writeFile(optimizedMapFilePath, JSON.stringify(optimizedMap));
             });
         },


### PR DESCRIPTION
This is an attempt to fix the

```
Unexpected early exit. This happens when Promises returned by plugins cannot resolve. Unfinished hook action(s) on exit:
(map-optimizer) writeBundle
```