### PR TITLE
Fixing regex to find the JS scripts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -187,7 +187,7 @@ function mapOptimizer(
             const scriptName = path.parse(scriptProperty.value).name;
             const fileName = fs
                 .readdirSync(assetsFolder)
-                .find((asset) => asset.match(new RegExp(`^${scriptName}-.*.js$`)));
+                .find((asset) => asset.match(new RegExp(`^${scriptName}-[a-fA-F0-9]{8}\\.js$`)));
 
             if (!fileName) {
                 throw new Error(`Undefined ${scriptName} script file`);


### PR DESCRIPTION
Previously, 2 scripts with similar names could be mixed.

For instance:

foo.ts and foo-hello.ts would be mixed because foo-hello-12345678.js matches the regex foo.*.js

The regex is now more specific