### PR TITLE
feat: Wrapping scripts into generated HTML file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- New `WaMapOptimizerOptions` interface extending `OptimizeOptions` with `playUrl` option
+- HTML wrapper generation for compiled scripts that includes the WorkAdventure iframe API
+- Support for `PLAY_URL` environment variable to configure the WorkAdventure Play URL
+
+### Changed
+
+- **BREAKING**: The `script` property in TMJ maps now points to an HTML wrapper file instead of directly to the compiled JS file
+- The HTML wrapper loads both the WorkAdventure iframe API (from the configured Play URL) and the compiled script
+- Generated HTML files follow the naming pattern `scriptname-hash.html` (matching the JS file hash)
+- Updated `getMapsOptimizers` signature to accept `WaMapOptimizerOptions` instead of `OptimizeOptions`
+
+### Notes
+
+- The `playUrl` can be configured via:
+  1. `playUrl` option in `WaMapOptimizerOptions`
+  2. `PLAY_URL` environment variable
+  3. Defaults to `https://play.workadventu.re` if neither is set
+
 ## [1.1.31](https://github.com/nolway/wa-map-optimizer-vite/compare/v1.1.30...v1.1.31) (2025-09-08)
 
 


### PR DESCRIPTION
We now automatically generate a HTML wrapper for each script loaded. Before, the scripts were loaded from a sandboxed iframe. The sandbox was hard to work with, especially forbidding CORS calls. The wrapper will be hosted along the map, usually in the map-storage where it has access to almost nothing from a security standpoint (the map-storage domain has no important cookies for instance). In the case of self-hosting in a single domain, we can assume the maps are uploaded by the administrator, so we don't need to protect ourselves agains rogue scripts from the maps.