### PR TITLE
fix: Correctly handling script name collisions

### DIFF
--- a/test/maps/map1/map1.tmj
+++ b/test/maps/map1/map1.tmj
@@ -1,0 +1,37 @@
+{
+  "compressionlevel": -1,
+  "height": 5,
+  "infinite": false,
+  "layers": [
+    {
+      "data": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+      "height": 5,
+      "id": 1,
+      "name": "floor",
+      "opacity": 1,
+      "type": "tilelayer",
+      "visible": true,
+      "width": 5,
+      "x": 0,
+      "y": 0
+    }
+  ],
+  "nextlayerid": 2,
+  "nextobjectid": 1,
+  "orientation": "orthogonal",
+  "renderorder": "right-down",
+  "tiledversion": "1.10.2",
+  "tileheight": 32,
+  "tilesets": [],
+  "tilewidth": 32,
+  "type": "map",
+  "version": "1.10",
+  "width": 5,
+  "properties": [
+    {
+      "name": "script",
+      "type": "string",
+      "value": "./scripts/main.ts"
+    }
+  ]
+}

--- a/test/maps/map1/scripts/main.ts
+++ b/test/maps/map1/scripts/main.ts
@@ -1,0 +1,5 @@
+console.log("Script from MAP1!");
+
+WA?.onInit?.(() => {
+    console.log("MAP1 script initialized");
+});

--- a/test/maps/map2/map2.tmj
+++ b/test/maps/map2/map2.tmj
@@ -1,0 +1,37 @@
+{
+  "compressionlevel": -1,
+  "height": 5,
+  "infinite": false,
+  "layers": [
+    {
+      "data": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+      "height": 5,
+      "id": 1,
+      "name": "floor",
+      "opacity": 1,
+      "type": "tilelayer",
+      "visible": true,
+      "width": 5,
+      "x": 0,
+      "y": 0
+    }
+  ],
+  "nextlayerid": 2,
+  "nextobjectid": 1,
+  "orientation": "orthogonal",
+  "renderorder": "right-down",
+  "tiledversion": "1.10.2",
+  "tileheight": 32,
+  "tilesets": [],
+  "tilewidth": 32,
+  "type": "map",
+  "version": "1.10",
+  "width": 5,
+  "properties": [
+    {
+      "name": "script",
+      "type": "string",
+      "value": "./scripts/main.ts"
+    }
+  ]
+}

--- a/test/maps/map2/scripts/main.ts
+++ b/test/maps/map2/scripts/main.ts
@@ -1,0 +1,5 @@
+console.log("Script from MAP2!");
+
+WA?.onInit?.(() => {
+    console.log("MAP2 script initialized");
+});

--- a/test/maps/map3/map3.tmj
+++ b/test/maps/map3/map3.tmj
@@ -1,0 +1,37 @@
+{
+  "compressionlevel": -1,
+  "height": 5,
+  "infinite": false,
+  "layers": [
+    {
+      "data": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+      "height": 5,
+      "id": 1,
+      "name": "floor",
+      "opacity": 1,
+      "type": "tilelayer",
+      "visible": true,
+      "width": 5,
+      "x": 0,
+      "y": 0
+    }
+  ],
+  "nextlayerid": 2,
+  "nextobjectid": 1,
+  "orientation": "orthogonal",
+  "renderorder": "right-down",
+  "tiledversion": "1.10.2",
+  "tileheight": 32,
+  "tilesets": [],
+  "tilewidth": 32,
+  "type": "map",
+  "version": "1.10",
+  "width": 5,
+  "properties": [
+    {
+      "name": "script",
+      "type": "string",
+      "value": "../map1/scripts/main.ts"
+    }
+  ]
+}


### PR DESCRIPTION
If 2 maps have the same "script" name in 2 different directories, the name of the scripts will not longer collide.